### PR TITLE
[fix] Nginx config location admin/ allowed network list

### DIFF
--- a/templates/nginx/site-conf.j2
+++ b/templates/nginx/site-conf.j2
@@ -65,7 +65,9 @@ server {
     {% if openwisp2_admin_allowed_network %}
     location /admin/ {
         try_files {{ openwisp2_path }}/public_html/maintenance.html $uri @uwsgi;
-        allow {{ openwisp2_admin_allowed_network }};
+        {% for network in openwisp2_admin_allowed_network %}
+        allow {{ network }};
+        {% endfor %}
         deny all;
     }
     {% endif %}


### PR DESCRIPTION
Unroll the allowed network list in location admin/, as explicited in nginx docs

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #518.

## Description of Changes

This loop unrolls the value of the variable, to pass nginx config parser
